### PR TITLE
Update DbHelper.php

### DIFF
--- a/src/DbHelper.php
+++ b/src/DbHelper.php
@@ -44,7 +44,7 @@ class DbHelper
         `status` ENUM('active','inactive','deleted') DEFAULT 'active',
         `comment` VARCHAR(256) DEFAULT NULL,
         `ts` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        `ts_updated` TIMESTAMP NOT NULL DEFAULT '0000-00-00 00:00:00',
+        `ts_updated` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
         PRIMARY KEY (`task_id`)
         ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8";
     }


### PR DESCRIPTION
MySQL throws invalid format on the zero-date string if column is TIMESTAMP. Changing to DATETIME or changing the default value to CURRENT_TIMESTAMP like I did here accomplishes the same thing without errors.
