### PR TITLE
Codeigniter example ui fixes

### DIFF
--- a/examples/codeigniter/application/controllers/TasksController.php
+++ b/examples/codeigniter/application/controllers/TasksController.php
@@ -22,6 +22,7 @@ class TasksController extends CI_Controller
         $this->load->model('DbBaseModel');
         $this->load->model('Task', 'task');
         $this->load->model('TaskRun', 'task_run');
+        $this->load->helper('url');
         $this->controller_folder = __DIR__ . '/../models';
 
         TaskLoader::setClassFolder($this->controller_folder);

--- a/examples/codeigniter/application/views/tasks/tasks_list.php
+++ b/examples/codeigniter/application/views/tasks/tasks_list.php
@@ -43,13 +43,13 @@ $this->load->view('tasks/template');
             <td><?= $t->ts ?></td>
             <td><?= $t->ts_updated ?></td>
             <td>
-                <a href="/TasksController/taskEdit?task_id=<?= $t->task_id ?>">Edit</a>
+                <a href="<?php echo site_url('TasksController/taskEdit') ?>?task_id=<?= $t->task_id ?>">Edit</a>
             </td>
             <td>
-                <a href="/TasksController/taskLog?task_id=<?= $t->task_id ?>">Log</a>
+                <a href="<?php echo site_url('TasksController/taskLog') ?>?task_id=<?= $t->task_id ?>">Log</a>
             </td>
             <td>
-                <a href="<?= $t->task_id ?>" class="run_task">Run</a>
+                <a href="<?php echo site_url('TasksController') ?>/<?= $t->task_id ?>" class="run_task">Run</a>
             </td>
         </tr>
     <?php endforeach; ?>

--- a/examples/codeigniter/application/views/tasks/template.php
+++ b/examples/codeigniter/application/views/tasks/template.php
@@ -38,7 +38,7 @@ $menu = array(
         <?php foreach ($menu as $m => $text):
             $class = (isset($_GET['m']) && ($_GET['m'] == $m)) ? 'active' : '';
             ?>
-            <li class="<?= $class ?>"><a href="/TasksController/<?= $m ?>"><?= $text ?></a></li>
+            <li class="<?= $class ?>"><a href="<?php echo site_url("TasksController/$m"); ?>"><?php echo $text ?></a></li>
         <?php endforeach; ?>
     </ul>
     <br>


### PR DESCRIPTION
The example had hard coded URL's .

Fixed by using codeigniter's site_url helper. This will make it easier to run the example in MAMP and wamp where the example cannot be in the root 
