### PR TITLE
fix creating table task in mysql version 5.5 and lower

### DIFF
--- a/src/DbHelper.php
+++ b/src/DbHelper.php
@@ -43,7 +43,7 @@ class DbHelper
         `command` VARCHAR(256) NOT NULL,
         `status` ENUM('active','inactive','deleted') DEFAULT 'active',
         `comment` VARCHAR(256) DEFAULT NULL,
-        `ts` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        `ts` TIMESTAMP NOT NULL DEFAULT 0,
         `ts_updated` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
         PRIMARY KEY (`task_id`)
         ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8";


### PR DESCRIPTION
in mysql 5.5 and lower we get error SQL Error (1293): Incorrect table definition; there can be only one TIMESTAMP column with CURRENT_TIMESTAMP in DEFAULT or ON UPDATE clause".
this commit fix this bug in mysql